### PR TITLE
Rewrite main code with new handler & add support for more keyboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,8 @@
+
+$(info $(shell mkdir -p bin))
+
+all: bwidow
+
 bwidow: src/bwidow.c
 	gcc -std=gnu99 src/bwidow.c -lusb-1.0 -o bin/bwidow
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![License](http://img.shields.io/:license-mit-blue.svg?style=flat)](http://badges.mit-license.org)
-
 # blackwidow_macro
 
 Razer BlackWidow Macro Keys Enabler
@@ -75,7 +73,7 @@ To remove you can do `make rmudev`
     M4 = 194
     M5 = 195
 
-### device id's included
+### Devices Included
 
     010D = "Razer BlackWidow Ultimate"
     010E = "Razer BlackWidow"
@@ -85,18 +83,13 @@ To remove you can do `make rmudev`
 
 If anyone wants me to add any more please tell me so I can add them in.
 
-### todo
-
-* ~~extract all known device id's of blackwidow keyboards from the Razer proprietary drivers~~
-* ~~add more blackwidow device id's~~
-
-### related references
+### Related References
 
 * [Wireshark USB Capture Setup](https://wiki.wireshark.org/CaptureSetup/USB)
 * [libusb on github](https://github.com/libusb/libusb)
 * [libusb wiki on github](https://github.com/libusb/libusb/wiki)
 
-### razer windows drivers
+### Razer Windows Drivers
 
 Device IDs taken from Razer BlackWidow drivers
 
@@ -107,3 +100,15 @@ Device IDs taken from Razer BlackWidow drivers
     %Razer010D.DeviceDesc%=Razer, HID\Vid_1532&Pid_010D&MI_00
     %Razer010E.DeviceDesc%=Razer, HID\Vid_1532&Pid_010E&MI_00
     %Razer011B.DeviceDesc%=Razer, HID\Vid_1532&Pid_011B&MI_00
+
+# Contact
+
+Website: https://equk.co.uk
+
+Mastodon: [@equilibriumuk@hachyderm.io](https://hachyderm.io/@equilibriumuk)
+
+Bluesky: [@equilibriumuk.bsky.social](https://bsky.app/profile/equilibriumuk.bsky.social)
+
+# License
+
+MIT License

--- a/README.md
+++ b/README.md
@@ -14,22 +14,40 @@ Dependencies: [libusb](http://libusb.info/)
 
 ## Usage
 
-    Razer BlackWidow Macro Keys v1.2
-    Razer BlackWidow 2013 Device Found
-    Sending data:
-     00 00 00 00 00 02 00 04
-     02 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     00 00 00 00 00 00 00 00
-     04 00
-    Transmitted: 90
+```sh
+Razer BlackWidow Macro Keys v2.0
+Sending Keyboard Macro Init Sequence for [1532:011b]
+
+Sending data:
+ 00 00 00 00 00 02 00 04
+ 02 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 00 00 00 00 00 00 00 00
+ 04 00
+Transmitted: 90
+```
+
+```sh
+Arguments:
+        -s      send init packet
+        -v      show verbose output
+```
+
+## Version 2.x
+
+improvements:
+
+- [x] new libusb handle
+- [x] array of keyboard device IDs
+- [x] new cli feedback
+- [x] support for more keyboard devices
 
 ## Notes
 
@@ -62,6 +80,8 @@ To remove you can do `make rmudev`
     010D = "Razer BlackWidow Ultimate"
     010E = "Razer BlackWidow"
     011B = "Razer BlackWidow 2013"
+    0203 = "Razer BlackWidow Chroma"
+    0221 = "Razer BlackWidow Chroma V2"
 
 If anyone wants me to add any more please tell me so I can add them in.
 

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -74,10 +74,13 @@ struct libusb_device_handle *usb_init(struct libusb_context *context, int venid,
     return handle;
 }
 
-void closeHandle () {
-    libusb_release_interface(handle, DEV_INTF);
-    libusb_close(handle);
-    libusb_exit(NULL);
+// Close USB Handle
+void usb_close(struct libusb_device_handle *handle)
+{
+    if (handle != NULL)
+    {
+        libusb_close(handle);
+    }
 }
 
 void printData (unsigned char * data) {

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -28,7 +28,11 @@ const int vendorId = 0x1532;
 const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203};
 
 // Version
-const char * BWIDOW_VERSION = "1.2";
+const char *BWIDOW_VERSION = "2.0";
+
+// CLI Options
+int verbose = 0;
+int send_init = 0;
 
 // Blackwidow M Key Init Code
 unsigned char Blackwidow_Init[90] =

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -25,12 +25,7 @@
 // vendor_id = Razer
 const int vendorId = 0x1532;
 // product_id of known blackwidow devices
-#define DEV_PID_BW_2013 0x011b
-#define DEV_PID_BW_ULT 0x010d
-#define DEV_PID_BW 0x010e
-
-// USB Device
-#define DEV_INTF 2
+const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203};
 
 // Version
 const char * BWIDOW_VERSION = "1.2";

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -23,7 +23,7 @@
 #include <string.h>
 
 // vendor_id = Razer
-#define DEV_VID 0x1532
+const int vendorId = 0x1532;
 // product_id of known blackwidow devices
 #define DEV_PID_BW_2013 0x011b
 #define DEV_PID_BW_ULT 0x010d

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -161,10 +161,16 @@ int main(int argc, char *argv[])
             send_init = 1;
         }
 
-        if (send_init) {
-        //Send Data
-            sendcmd(Blackwidow_Init);
-        }
+        if (send_init)
+        {
+
+            struct libusb_context *context;
+            struct libusb_device_handle *handle = NULL;
+
+            libusb_init(&context);
+            libusb_set_option(NULL, LIBUSB_OPTION_LOG_LEVEL, 3);
+
+            int vid = vendorId;
 
             int i;
 

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -110,31 +110,37 @@ int sendcmd(unsigned char *data, struct libusb_device_handle *handle)
     int res;
     res = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_CLASS, 0x9, 0x300, 0, data, 90, 1000);
 
-    if (verbose) {
+    if (verbose)
+    {
         printf("Transmitted: %d\n", res);
     }
+
     return res;
 }
 
 // Console argument parsing
-int scanArgs (char* arg, char* argv[], int argc) {
+int scanArgs(char *arg, char *argv[], int argc)
+{
     int i = 0;
-    for (i = 1; i < argc; i++) {
-        if (strcmp(arg, argv[i]) == 0) {
+    for (i = 1; i < argc; i++)
+    {
+        if (strcmp(arg, argv[i]) == 0)
+        {
             return i;
         }
     }
     return 0;
 }
 
-// Main
-int main (int argc, char * argv[]) {
+int main(int argc, char *argv[])
+{
+
     printf("Razer BlackWidow Macro Keys v%s\n", BWIDOW_VERSION);
 
-    if ( argc<2 )
+    if (argc < 2)
     {
         // Show Help Banner If No Args Given
-        printf("\nUsage: %s <arg>\n",argv[0]);
+        printf("\nUsage: %s <arg>\n", argv[0]);
         printf("\nArguments:\n \t-s\tsend init packet\n");
         printf("\t-v\tshow verbose output\n");
         printf("\nNote: This script requires root access for kernel driver\n");
@@ -143,15 +149,15 @@ int main (int argc, char * argv[]) {
     else
     {
 
-        if (init() != 0) return 1;
-
         // Verbose mode
-        if (scanArgs("-v", argv, argc)) {
+        if (scanArgs("-v", argv, argc))
+        {
             verbose = 1;
         }
 
-        // Send Button Init Command
-        if (scanArgs("-s", argv, argc)){
+        // Send Macro Init Command
+        if (scanArgs("-s", argv, argc))
+        {
             send_init = 1;
         }
 

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -83,11 +83,14 @@ void usb_close(struct libusb_device_handle *handle)
     }
 }
 
-void printData (unsigned char * data) {
+void printData(unsigned char *data)
+{
     int k = 0;
-    for (int i = 0; i < 90; i++) {
+    for (int i = 0; i < 90; i++)
+    {
         printf(" %02x", data[i]);
-        if (k++ == 7) {
+        if (k++ == 7)
+        {
             printf("\n");
             k = 0;
         }

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -99,16 +99,16 @@ void printData(unsigned char *data)
 }
 
 // Send data to USB
-int sendcmd (unsigned char * data) {
-    if (verbose) {
+int sendcmd(unsigned char *data, struct libusb_device_handle *handle)
+{
+    if (verbose)
+    {
         printf("Sending data:\n");
         printData(data);
     }
 
     int res;
-    res = libusb_control_transfer(handle,
-        LIBUSB_REQUEST_TYPE_CLASS,
-        0x9, 0x300, 0, data, 90, 1000);
+    res = libusb_control_transfer(handle, LIBUSB_REQUEST_TYPE_CLASS, 0x9, 0x300, 0, data, 90, 1000);
 
     if (verbose) {
         printf("Transmitted: %d\n", res);

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -166,7 +166,26 @@ int main(int argc, char *argv[])
             sendcmd(Blackwidow_Init);
         }
 
-        closeHandle();
+            int i;
+
+            for (i = 0; i < 5; i++)
+            {
+                // DEBUG
+                // printf("[%04x:%04x]\n", vid, keyboardIds[i]);
+                int pid = keyboardIds[i];
+                handle = usb_init(context, vid, pid);
+                if (handle != NULL)
+                {
+                    printf("Sending Keyboard Macro Init Sequence for [%04x:%04x]\n\n", vid, pid);
+
+                    sendcmd(Blackwidow_Init, handle);
+
+                    usb_close(handle);
+                    libusb_exit(NULL);
+                }
+            }
+        }
     }
+
     return 0;
 }

--- a/udev/99-bwidow.rules
+++ b/udev/99-bwidow.rules
@@ -1,3 +1,5 @@
-ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="011b", RUN+="/usr/bin/bwidow -s"
-ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="010d", RUN+="/usr/bin/bwidow -s"
-ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="010e", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="011b", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="010d", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="010e", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0221", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0203", RUN+="/usr/bin/bwidow -s"


### PR DESCRIPTION
## New Features

- [x] new libusb handle
- [x] array of keyboard device IDs
- [x] new cli feedback
- [x] support for more blackwidow keyboards

## Changes

* add array of known keyboard device IDs
* rewrite device handler using `libusb_get_device_list` & `libusb_open`
* search for devices using `keyboardIds` & open handle using new handler function
* if device is found & handler is open, send macro init code using handler
* update Makefile to create bin folder if none exists
* add more device ids of known keyboards to udev rules
* Update README with info on new features & changes for 2.0
* add Contact & License sections to README
