### PR TITLE
Add Blackwidow Ultimate 2014 product ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ To remove you can do `make rmudev`
     011B = "Razer BlackWidow 2013"
     0203 = "Razer BlackWidow Chroma"
     0221 = "Razer BlackWidow Chroma V2"
+    011A = "Razer BlackWidow Ultimate 2014"
 
 If anyone wants me to add any more please tell me so I can add them in.
 

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -25,7 +25,7 @@
 // vendor_id = Razer
 const int vendorId = 0x1532;
 // product_id of known blackwidow devices
-const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203};
+const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203, 0x011a};
 
 // Version
 const char *BWIDOW_VERSION = "2.0";

--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 
             int i;
 
-            for (i = 0; i < 5; i++)
+            for (i = 0; i < 6; i++)
             {
                 // DEBUG
                 // printf("[%04x:%04x]\n", vid, keyboardIds[i]);

--- a/udev/99-bwidow.rules
+++ b/udev/99-bwidow.rules
@@ -3,3 +3,4 @@ SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATT
 SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="010e", RUN+="/usr/bin/bwidow -s"
 SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0221", RUN+="/usr/bin/bwidow -s"
 SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0203", RUN+="/usr/bin/bwidow -s"
+SUBSYSTEM=="usb", ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="011a", RUN+="/usr/bin/bwidow -s"


### PR DESCRIPTION
The keyboard says Blackwidow Ultimate 2014 on the bottom sticker, but is reported as 2013 with a different product id:

```
❯ lsusb -d 1532:
Bus 001 Device 015: ID 1532:011a Razer USA, Ltd BlackWidow Ultimate 2013
```