### PR TITLE
add support for device blackwidow v4 x

### DIFF
--- a/src/bwidow.c
+++ b/src/bwidow.c
@@ -25,7 +25,7 @@
 // vendor_id = Razer
 const int vendorId = 0x1532;
 // product_id of known blackwidow devices
-const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203, 0x011a};
+const int keyboardIds[] = {0x011b, 0x010d, 0x010e, 0x0221, 0x0203, 0x011a, 0x0293};
 
 // Version
 const char *BWIDOW_VERSION = "2.0";
@@ -178,7 +178,7 @@ int main(int argc, char *argv[])
 
             int i;
 
-            for (i = 0; i < 6; i++)
+            for (i = 0; i < 7; i++)
             {
                 // DEBUG
                 // printf("[%04x:%04x]\n", vid, keyboardIds[i]);

--- a/udev/99-bwidow.rules
+++ b/udev/99-bwidow.rules
@@ -4,3 +4,4 @@ ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="01
 ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0221", RUN+="/usr/bin/bwidow -s"
 ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0203", RUN+="/usr/bin/bwidow -s"
 ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="011a", RUN+="/usr/bin/bwidow -s"
+ACTION=="add", SUBSYSTEM=="input",ATTRS{idVendor}=="1532", ATTRS{idProduct}=="0293", RUN+="/usr/bin/bwidow -s"


### PR DESCRIPTION
- [x] add device id for blackwidow v4 x
- [x] add udev rules for blackwidow v4 x

```
Device Name: Razer BlackWidow V4 X
USB Vendor ID: 1532
USB Product ID: 0293
```

ref: #9 